### PR TITLE
Implement color mode toggle

### DIFF
--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -7,10 +7,10 @@ import React, {
   useState
 } from 'react';
 
-import {ColorModeToggleProps} from './types';
+import {ColorModeContextValue, ColorModeToggleProps} from './types';
 import {createDefaultVariables, getColorValue} from './helpers';
 
-const ColorModeContext = createContext({});
+const ColorModeContext = createContext({} as ColorModeContextValue);
 
 export function ColorModeToggle({
   theme,
@@ -72,4 +72,5 @@ export function ColorModeToggle({
   );
 }
 
-export const useColorMode = () => useContext(ColorModeContext);
+export const useColorMode = (): ColorModeContextValue =>
+  useContext(ColorModeContext);

--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -1,0 +1,75 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+
+import {ColorModeToggleProps} from './types';
+import {createDefaultVariables, getColorValue} from './helpers';
+
+const ColorModeContext = createContext({});
+
+export function ColorModeToggle({
+  theme,
+  children,
+  customVariables
+}: ColorModeToggleProps): JSX.Element {
+  const [colorMode, setColorMode] = useState(undefined);
+
+  const defaultVariables = useMemo(() => createDefaultVariables(theme), [
+    theme
+  ]);
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    const initialColorValue = root.style.getPropertyValue(
+      '--chakra-ui-color-mode'
+    );
+
+    setColorMode(initialColorValue);
+  }, []);
+
+  const toggleColorMode = useCallback(() => {
+    const root = window.document.documentElement;
+
+    setColorMode(prev => {
+      const newColorMode = prev === 'dark' ? 'light' : 'dark';
+      const isLightMode = newColorMode === 'dark';
+
+      localStorage.setItem('chakra-ui-color-mode', newColorMode);
+
+      Object.entries({
+        ...defaultVariables,
+        ...customVariables
+      }).forEach(([name, values]) =>
+        root.style.setProperty(
+          name,
+          isLightMode
+            ? `${getColorValue(theme, values[1])}`
+            : `${getColorValue(theme, values[0])}`
+        )
+      );
+
+      return newColorMode;
+    });
+  }, [colorMode]);
+
+  const payload = useMemo(
+    () => ({
+      colorMode,
+      toggleColorMode
+    }),
+    [colorMode, toggleColorMode]
+  );
+
+  return (
+    <ColorModeContext.Provider value={payload}>
+      {children}
+    </ColorModeContext.Provider>
+  );
+}
+
+export const useColorMode = () => useContext(ColorModeContext);

--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -39,8 +39,6 @@ export function ColorModeToggle({
       const newColorMode = prev === 'dark' ? 'light' : 'dark';
       const isDarkMode = newColorMode === 'dark';
 
-      localStorage.setItem('chakra-ui-color-mode', newColorMode);
-
       Object.entries({
         ...defaultVariables,
         ...customVariables

--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -37,7 +37,7 @@ export function ColorModeToggle({
 
     setColorMode(prev => {
       const newColorMode = prev === 'dark' ? 'light' : 'dark';
-      const isLightMode = newColorMode === 'dark';
+      const isDarkMode = newColorMode === 'dark';
 
       localStorage.setItem('chakra-ui-color-mode', newColorMode);
 
@@ -47,7 +47,7 @@ export function ColorModeToggle({
       }).forEach(([name, values]) =>
         root.style.setProperty(
           name,
-          isLightMode
+          isDarkMode
             ? `${getColorValue(theme, values[1])}`
             : `${getColorValue(theme, values[0])}`
         )

--- a/src/FlashlessScript.tsx
+++ b/src/FlashlessScript.tsx
@@ -3,6 +3,8 @@ import {Dict} from '@chakra-ui/utils';
 import {getColor, transparentize} from '@chakra-ui/theme-tools';
 import {outdent} from 'outdent';
 
+import {Color, Variables} from './types';
+
 const baseVariables = {
   '--bg': ['white', 'gray.800'],
   '--text': ['gray.800', 'whiteAlpha.900'],
@@ -10,9 +12,6 @@ const baseVariables = {
   '--border': ['gray.200', 'whiteAlpha.300'],
   '--badge-text': ['white', 'whiteAlpha.800']
 };
-
-type Color = string | [string, number];
-type Variables = Record<string, [Color, Color]>;
 
 function createVariables(theme: Dict, customVariables?: Variables): string {
   function colorValue(color: Color) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,7 @@
+export const BASE_VARIABLES = {
+  '--bg': ['white', 'gray.800'],
+  '--text': ['gray.800', 'whiteAlpha.900'],
+  '--placeholder-text': ['gray.400', 'whiteAlpha.400'],
+  '--border': ['gray.200', 'whiteAlpha.300'],
+  '--badge-text': ['white', 'whiteAlpha.800']
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,6 @@
-export const BASE_VARIABLES = {
+import {Variables} from './types';
+
+export const BASE_VARIABLES: Variables = {
   '--bg': ['white', 'gray.800'],
   '--text': ['gray.800', 'whiteAlpha.900'],
   '--placeholder-text': ['gray.400', 'whiteAlpha.400'],

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,50 @@
+import {Color} from './types';
+import {Dict} from '@chakra-ui/utils';
+import {getColor, transparentize} from '@chakra-ui/theme-tools';
+
+import {BASE_VARIABLES} from './constants';
+
+export function createDefaultVariables(theme: Dict) {
+  return Object.entries(theme.colors)
+    .filter(entries => typeof entries[1] === 'object')
+    .reduce((acc, [c]) => {
+      const isGray = c === 'gray';
+      return {
+        ...acc,
+        [`--badge-solid-${c}`]: [`${c}.500`, [`${c}.500`, 0.6]],
+        [`--badge-subtle-${c}`]: [`${c}.100`, [`${c}.200`, 0.16]],
+        [`--badge-subtle-${c}-text`]: [`${c}.800`, `${c}.200`],
+        [`--badge-outline-${c}`]: [`${c}.500`, [`${c}.200`, 0.8]],
+        [`--button-ghost-${c}`]: [
+          isGray ? 'inherit' : `${c}.600`,
+          isGray ? 'whiteAlpha.900' : `${c}.200`
+        ],
+        [`--button-ghost-${c}-hover`]: [
+          `${c}.${isGray ? 100 : 50}`,
+          isGray ? 'whiteAlpha.200' : [`${c}.200`, 0.12]
+        ],
+        [`--button-ghost-${c}-active`]: [
+          `${c}.${isGray ? 200 : 100}`,
+          isGray ? 'whiteAlpha.300' : [`${c}.200`, 0.24]
+        ],
+        [`--button-solid-${c}`]: [
+          `${c}.${isGray ? 100 : 500}`,
+          isGray ? 'whiteAlpha.200' : `${c}.200`
+        ],
+        [`--button-solid-${c}-hover`]: [
+          `${c}.${isGray ? 200 : 600}`,
+          isGray ? 'whiteAlpha.300' : `${c}.300`
+        ],
+        [`--button-solid-${c}-active`]: [
+          `${c}.${isGray ? 300 : 700}`,
+          isGray ? 'whiteAlpha.400' : `${c}.400`
+        ]
+      };
+    }, BASE_VARIABLES);
+}
+
+export function getColorValue(theme: Dict, color: Color): string {
+  return Array.isArray(color)
+    ? transparentize(...color)(theme)
+    : getColor(theme, color);
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,10 +1,10 @@
-import {Color} from './types';
+import {Color, Variables} from './types';
 import {Dict} from '@chakra-ui/utils';
 import {getColor, transparentize} from '@chakra-ui/theme-tools';
 
 import {BASE_VARIABLES} from './constants';
 
-export function createDefaultVariables(theme: Dict) {
+export function createDefaultVariables(theme: Dict): Variables {
   return Object.entries(theme.colors)
     .filter(entries => typeof entries[1] === 'object')
     .reduce((acc, [c]) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,5 @@
+import * as Types from './types';
 export * from './FlashlessScript';
 export * from './flashless';
+
+export {Types};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import {ColorMode} from '@chakra-ui/react';
 import {Dict} from '@chakra-ui/utils';
 import {PropsWithChildren} from 'react';
 
@@ -7,3 +8,7 @@ export type ColorModeToggleProps = PropsWithChildren<{
   theme: Dict;
   customVariables: Variables;
 }>;
+export type ColorModeContextValue = {
+  colorMode: ColorMode;
+  toggleColorMode: () => void;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,2 +1,9 @@
+import {Dict} from '@chakra-ui/utils';
+import {PropsWithChildren} from 'react';
+
 export type Color = string | [string, number];
 export type Variables = Record<string, [Color, Color]>;
+export type ColorModeToggleProps = PropsWithChildren<{
+  theme: Dict;
+  customVariables: Variables;
+}>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,2 @@
+export type Color = string | [string, number];
+export type Variables = Record<string, [Color, Color]>;


### PR DESCRIPTION
## Description 

Implement context provider to toggle color mode. The color mode is initialize based on the system preference and this PR does not implement the functionally to also persist the color mode value via local storage, although it can be implemented later.

I've also created separate files to structure helpers and constants, to be able to reuse them in other modules. 

## Implementation Styles

Execute `ToggleModeProvider` passing the `theme` and `customVariables` as properties

```jsx
 <ColorModeToggle theme={theme} customVariables={colorModeVariables}>
   {...}
 </ColorModeToggle>
 ```
 
 Toggle color mode by accessing the `toggleColorMode` function provided in the context value

 ```js
  const { colorMode, toggleColorMode } = useColorMode()
 ```
 
 It's also possible to access the current color mode state value
 
 ## Tasks
 - [ ] Implement `ColorModeToggle` provider to toggle color mode and redefine CSS variables
 - [ ] Update docs with `ColorModeToggle`  instructions